### PR TITLE
Core: Adding promise handling on qunit callbacks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,6 +143,7 @@ module.exports = function( grunt ) {
 						"test/reorderError1.html",
 						"test/reorderError2.html",
 						"test/callbacks.html",
+						"test/callbacks-promises.html",
 						"test/events.html",
 						"test/events-in-test.html",
 						"test/logs.html",

--- a/src/core.js
+++ b/src/core.js
@@ -143,6 +143,11 @@ function scheduleBegin() {
 	}
 }
 
+function unblockAndAdvanceQueue() {
+	config.blocking = false;
+	ProcessingQueue.advance();
+}
+
 export function begin() {
 	var i, l,
 		modulesLog = [];
@@ -171,11 +176,10 @@ export function begin() {
 		runLoggingCallbacks( "begin", {
 			totalTests: Test.count,
 			modules: modulesLog
-		} );
+		} ).then( unblockAndAdvanceQueue );
+	} else {
+		unblockAndAdvanceQueue();
 	}
-
-	config.blocking = false;
-	ProcessingQueue.advance();
 }
 
 exportQUnit( QUnit );

--- a/src/core/logging.js
+++ b/src/core/logging.js
@@ -34,10 +34,7 @@ export function registerLoggingCallbacks( obj ) {
 }
 
 export function runLoggingCallbacks( key, args ) {
-	var i, l, callbacks;
-
-	callbacks = config.callbacks[ key ];
-	for ( i = 0, l = callbacks.length; i < l; i++ ) {
-		callbacks[ i ]( args );
-	}
+	var callbacks = config.callbacks[ key ];
+	var promises = callbacks.map( callback => Promise.resolve( callback( args ) ) );
+	return Promise.all( promises );
 }

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -31,33 +31,46 @@ const taskQueue = [];
  * process the testQueue
  */
 function advance() {
-	advanceTaskQueue();
-
-	if ( !taskQueue.length ) {
+	if ( taskQueue.length ) {
+		advanceTaskQueue();
+	} else {
 		advanceTestQueue();
 	}
 }
 
 /**
- * Advances the taskQueue to the next task if it is ready and not empty.
+ * Advances the taskQueue with an increased depth
  */
 function advanceTaskQueue() {
 	const start = now();
 	config.depth = ( config.depth || 0 ) + 1;
 
-	while ( taskQueue.length && !config.blocking ) {
+	processTaskQueue( start );
+
+	config.depth--;
+}
+
+/**
+ * Process the first task on the taskQueue as a promise.
+ * Each task is a function returned by https://github.com/qunitjs/qunit/blob/master/src/test.js#L381
+ */
+function processTaskQueue( start ) {
+	if ( taskQueue.length && !config.blocking ) {
 		const elapsedTime = now() - start;
 
 		if ( !defined.setTimeout || config.updateRate <= 0 || elapsedTime < config.updateRate ) {
 			const task = taskQueue.shift();
-			task();
+			Promise.resolve( task() ).then( function() {
+				if ( !taskQueue.length ) {
+					advance();
+				} else {
+					processTaskQueue( start );
+				}
+			} );
 		} else {
 			setTimeout( advance );
-			break;
 		}
 	}
-
-	config.depth--;
 }
 
 /**

--- a/test/callbacks-promises.html
+++ b/test/callbacks-promises.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Callbacks Test Suite</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script src="../dist/qunit.js"></script>
+	<script src="callbacks-promises.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+	<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/test/callbacks-promises.js
+++ b/test/callbacks-promises.js
@@ -1,0 +1,70 @@
+var done = false;
+var callbackCalled = {};
+
+function timeoutPromiseCallback( callback, timeout ) {
+	return new Promise( function( resolve ) {
+		setTimeout( function() {
+			callback();
+			resolve();
+		}, timeout );
+	} );
+}
+
+QUnit.begin( function() {
+	return timeoutPromiseCallback( function() {
+		callbackCalled.begin = true;
+	}, 100 );
+} );
+QUnit.moduleStart( function() {
+	return timeoutPromiseCallback( function() {
+		callbackCalled.moduleStart = true;
+	}, 100 );
+} );
+QUnit.testStart( function() {
+	return timeoutPromiseCallback( function() {
+		callbackCalled.testStart = true;
+	}, 100 );
+} );
+
+QUnit.testDone( function() {
+	return timeoutPromiseCallback( function() {
+		callbackCalled.testStart = false;
+		callbackCalled.testDone = true;
+	}, 100 );
+} );
+QUnit.moduleDone( function() {
+	return timeoutPromiseCallback( function() {
+		callbackCalled.moduleStart = false;
+		callbackCalled.moduleDone = true;
+	}, 100 );
+} );
+QUnit.done( function() {
+	return timeoutPromiseCallback( function() {
+		callbackCalled.done = true;
+	}, 100 );
+} );
+
+QUnit.done( function() {
+	if ( done ) {
+		return;
+	}
+
+	done = true;
+
+	QUnit.test( "verify callback order", function( assert ) {
+		assert.ok( callbackCalled.begin );
+		assert.notOk( callbackCalled.moduleStart );
+		assert.notOk( callbackCalled.testStart );
+		assert.ok( callbackCalled.testDone );
+		assert.ok( callbackCalled.moduleDone );
+		assert.ok( callbackCalled.done );
+	} );
+} );
+
+QUnit.module( "module1", function() {
+	QUnit.test( "test1", function( assert ) {
+		assert.ok( callbackCalled.begin );
+		assert.ok( callbackCalled.moduleStart );
+		assert.ok( callbackCalled.testStart );
+	} );
+} );


### PR DESCRIPTION
This change consist of several parts allowing qunit callbacks to handle promises:

1. Make advanceTaskQueue handle promises
Each QUnit Test consist of multiple tasks, which handles setup, test execution, teardown and reporting of test results.
"advanceTaskQueue" is the function that controls the execution flow of tasks from each test. Hence, this needs to be able to handle promises that are returned by tasks.

2. 'runLoggingCallbacks' returning a promise
'runLoggingCallbacks' is the function that executes each callback (begin, moduleStart, testStart, testDone, moduleDone, done) function that is registered. This will now return a promise, with each callback resolved as a promise. 
* Note: since we are returning Promise.all(callbackPromises), it does not resolve promises in sequential order. Open to make it handle sequentially.

3. Update 'runLoggingCallbacks' usage to handle promises.
Since 'runLoggingCallbacks' returns a promise, the corresponding functions that calls it will have to return the promise chain to handle the code that follows. The promise will end up being waited by 'advanceTaskQueue', and will move forward when the promise is resolved.'
* Note2: the promises returned by runLoggingCallbacks('log') and runLoggingCallbacks('done') are not handled yet. 